### PR TITLE
Update requirements and setup with lxml and requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 beautifulsoup4==4.5.1
 lxml==3.6.4
 pymongo==3.3.1
+requests==2.19.1

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ setup (
   license='MIT',
   install_requires=[
     'beautifulsoup4==4.5.1',
+    'lxml==3.6.4',
     'pymongo==3.3.1',
+    'requests==2.19.1'    
   ],
 )


### PR DESCRIPTION
This adds requests and lxml to requirements.txt and setup.py

Currently lexis-nexis-wsk requires lxml and requests in order to run -- however it does not specify requests in either requirements.txt or in setup.py, and does not specify lxml in setup.py.